### PR TITLE
feat: remove form-data dependency and implement pure Buffer solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,12 +85,10 @@
   "dependencies": {
     "@langchain/core": "^0.3.72",
     "@langchain/openai": "^0.6.9",
-    "form-data": "^4.0.4",
     "https-proxy-agent": "^7.0.0",
     "lodash": "^4.17.21"
   },
   "overrides": {
-    "axios": "^1.12.0",
-    "form-data": "^4.0.4"
+    "axios": "^1.12.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,14 +14,11 @@ importers:
       '@langchain/openai':
         specifier: ^0.6.9
         version: 0.6.13(@langchain/core@0.3.77(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@5.12.2(zod@3.25.67)))
-      form-data:
-        specifier: ^4.0.4
-        version: 4.0.4
       https-proxy-agent:
         specifier: ^7.0.0
         version: 7.0.6
       lodash:
-        specifier: '>=4.17.0'
+        specifier: ^4.17.21
         version: 4.17.21
     devDependencies:
       '@types/lodash':
@@ -49,7 +46,7 @@ importers:
         specifier: ^1.14.1
         version: 1.112.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@5.12.2(zod@3.25.67))
       n8n-workflow:
-        specifier: ^1.82.0
+        specifier: ^1.17.0
         version: 1.110.0
       prettier:
         specifier: 3.3.3

--- a/src/nodes/InformationExtractionUpstage/InformationExtractionUpstage.node.ts
+++ b/src/nodes/InformationExtractionUpstage/InformationExtractionUpstage.node.ts
@@ -140,7 +140,8 @@ export class InformationExtractionUpstage implements INodeType {
 					{ name: 'Generate Schema', value: 'schema' },
 				],
 				default: 'extract',
-				description: 'Choose between extracting information with a schema or generating a schema from a document',
+				description:
+					'Choose between extracting information with a schema or generating a schema from a document',
 			},
 			// Input method
 			{
@@ -208,7 +209,9 @@ export class InformationExtractionUpstage implements INodeType {
 				type: 'string',
 				default: 'document_schema',
 				description: 'Name for the JSON schema in response_format',
-				displayOptions: { show: { operation: ['extract'], schemaInputType: ['schema'] } },
+				displayOptions: {
+					show: { operation: ['extract'], schemaInputType: ['schema'] },
+				},
 			},
 			{
 				displayName: 'JSON Schema (object)',
@@ -216,7 +219,9 @@ export class InformationExtractionUpstage implements INodeType {
 				type: 'json',
 				default: '{ "type": "object", "properties": {} }',
 				description: 'Target JSON schema for extraction (object schema)',
-				displayOptions: { show: { operation: ['extract'], schemaInputType: ['schema'] } },
+				displayOptions: {
+					show: { operation: ['extract'], schemaInputType: ['schema'] },
+				},
 			},
 			{
 				displayName: 'Full Response Format JSON',
@@ -226,7 +231,9 @@ export class InformationExtractionUpstage implements INodeType {
 					'{"type":"json_schema","json_schema":{"name":"document_schema","schema":{"type":"object","properties":{}}}}',
 				description:
 					'Complete response_format JSON (including type, json_schema, name, and schema)',
-				displayOptions: { show: { operation: ['extract'], schemaInputType: ['full'] } },
+				displayOptions: {
+					show: { operation: ['extract'], schemaInputType: ['full'] },
+				},
 			},
 			// Guidance for schema generation
 			{
@@ -377,7 +384,9 @@ export class InformationExtractionUpstage implements INodeType {
 
 								// Step 4: Required structure validation
 								if (!parsedJson.type || !parsedJson.json_schema) {
-									throw new Error('Missing required fields: type or json_schema');
+									throw new Error(
+										'Missing required fields: type or json_schema'
+									);
 								}
 
 								responseFormat = parsedJson;
@@ -455,11 +464,12 @@ export class InformationExtractionUpstage implements INodeType {
 						json: true,
 					};
 
-					const response = await this.helpers.httpRequestWithAuthentication.call(
-						this,
-						'upstageApi',
-						requestOptions
-					);
+					const response =
+						await this.helpers.httpRequestWithAuthentication.call(
+							this,
+							'upstageApi',
+							requestOptions
+						);
 
 					if (returnMode === 'full') {
 						returnData.push({ json: response, pairedItem: { item: i } });
@@ -545,11 +555,12 @@ export class InformationExtractionUpstage implements INodeType {
 					};
 
 					// Call
-					const response = await this.helpers.httpRequestWithAuthentication.call(
-						this,
-						'upstageApi',
-						requestOptions
-					);
+					const response =
+						await this.helpers.httpRequestWithAuthentication.call(
+							this,
+							'upstageApi',
+							requestOptions
+						);
 
 					// Response parsing + binary passthrough
 					if (returnMode === 'full') {


### PR DESCRIPTION
## Overview
Remove external `form-data` dependency and implement pure Node.js Buffer solution for multipart/form-data creation.

## Changes
- Remove `form-data` package from dependencies
- Implement `createMultipartFormData` helper function
- Update `DocumentParsingUpstage` and `DocumentOCRUpstage` nodes
- Improve error handling and type safety
- All functionality tested and working

## Testing
- `DocumentParsingUpstage`: All operations working
- `DocumentOCRUpstage`: All return modes working
- No form-data imports in compiled code
- Local n8n testing successful