### PR TITLE
Add debug logging for Solar Chat Model initialization

### DIFF
--- a/src/nodes/LmChatModelUpstage/LmChatModelUpstage.node.ts
+++ b/src/nodes/LmChatModelUpstage/LmChatModelUpstage.node.ts
@@ -472,6 +472,15 @@ export class LmChatModelUpstage implements INodeType {
 
 		const model = new ChatOpenAI(modelConfig);
 
+		// Debug logging for troubleshooting tool calling issues
+		console.log(`🔍 [Solar Chat Model] Initialized: ${modelName}`, {
+			hasMaxTokens: !!modelConfig.maxTokens,
+			hasTemperature: !!modelConfig.temperature,
+			streaming: modelConfig.streaming,
+			baseURL: modelConfig.configuration?.baseURL,
+			isNightly: modelName.includes('nightly'),
+		});
+
 		return {
 			response: model,
 		};


### PR DESCRIPTION
## Description

Add console logging to `LmChatModelUpstage` to help diagnose tool calling issues with different Solar model versions.

## Motivation

Users reported that `solar-pro2-nightly` does not perform tool calling in n8n AI Agent, while `solar-pro2` works correctly.

## Testing Results

Direct API testing confirms both models support tool calling:
- ✅ `solar-pro2`: Tool calling works
- ✅ `solar-pro2-nightly`: Tool calling works

LangChain testing also confirms both work:
- ✅ `solar-pro2`: LangChain `bind({ tools })` works
- ✅ `solar-pro2-nightly`: LangChain `bind({ tools })` works

This suggests the issue is in the integration layer (n8n AI Agent ↔ LangChain ↔ Upstage API).

## Changes

- Add debug console.log when `ChatOpenAI` model is initialized
- Log includes: model name, configuration settings, and nightly flag
- No functional changes - only diagnostic improvements
- Helps compare initialization between different model versions

## Example Log Output

```typescript
🔍 [Solar Chat Model] Initialized: solar-pro2 {
  hasMaxTokens: true,
  hasTemperature: true,
  streaming: false,
  baseURL: 'https://api.upstage.ai/v1',
  isNightly: false
}
```

## Checklist

- [x] Code builds successfully
- [x] No functional changes (logging only)
- [x] Tested with both solar-pro2 and solar-pro2-nightly